### PR TITLE
Poistin 'käynnissä' muuttujasta ääkköset, koska avautuu vääränlaisena om...

### DIFF
--- a/Maila.java
+++ b/Maila.java
@@ -13,7 +13,7 @@ public class Maila {
 	
 	Rectangle rajat;
 	
-	boolean ylös = false;
+	boolean ylos = false;
 	boolean alas = false;
 	
 	
@@ -33,7 +33,7 @@ public class Maila {
 		 
 		 rajat.setBounds(x, y, leveys, korkeus);
 		 
-		  if(ylös && y > 0)
+		  if(ylos && y > 0)
 			  y -= vauhti;
 		  if(alas && y < peli.getHeight() - korkeus)
 			  y += vauhti;

--- a/Maila2.java
+++ b/Maila2.java
@@ -13,7 +13,7 @@ public class Maila2 {
 	
 	Rectangle rajat;
 	
-	boolean ylös2 = false;
+	boolean ylos2 = false;
 	boolean alas2 = false;
 	
 
@@ -29,7 +29,7 @@ public class Maila2 {
 		 
 		 rajat.setBounds(x, y, leveys, korkeus);
 		 
-		  if(ylös2 && y > 0)
+		  if(ylos2 && y > 0)
 			  y -= vauhti;
 		  if(alas2 && y < peli.getHeight() - korkeus)
 			  y += vauhti;

--- a/Painallukset.java
+++ b/Painallukset.java
@@ -19,7 +19,7 @@ public class Painallukset implements KeyListener {
 		int nappi = e.getKeyCode();
 		
 		if(nappi == KeyEvent.VK_W){
-			Pong.pelaaja.ylÃ¶s=true;
+			Pong.pelaaja.ylös=true;
 		}
 		
 		if(nappi == KeyEvent.VK_S){
@@ -42,7 +42,7 @@ public class Painallukset implements KeyListener {
 	public void keyReleased(KeyEvent e) {
 		int nappi = e.getKeyCode();
 		if(nappi == KeyEvent.VK_W){
-			Pong.pelaaja.ylÃ¶s=false;
+			Pong.pelaaja.ylös=false;
 		}
 		
 		if(nappi == KeyEvent.VK_S){

--- a/Pong.java
+++ b/Pong.java
@@ -21,7 +21,7 @@ public class Pong extends Canvas implements Runnable{
 	public final int KORKEUS = LEVEYS / 16 * 9;
 	public final Dimension ruudunKoko = new Dimension(LEVEYS, KORKEUS);
 	public final String OTSIKKO = "Balamaui - Pong";
-	static boolean k√§ynniss√§ = false;
+	static boolean kaynnissa = false;
 	Image tausta;
 	
 	
@@ -37,6 +37,7 @@ public class Pong extends Canvas implements Runnable{
 		ikkuna.setTitle(OTSIKKO);
 		ikkuna.setBackground(Color.BLACK);
 		ikkuna.setLocationRelativeTo(null);
+		/* Ei voi k‰ytt‰‰ absoluuttista polkua, kuva pit‰isi lis‰t‰ v‰h projektin juureen*/
 		ImageIcon i = new ImageIcon("C:/Users/juhom_000/Downloads/Kentta.png");
 		tausta = i.getImage();
 		avain = new Painallukset(this);
@@ -48,7 +49,7 @@ public class Pong extends Canvas implements Runnable{
 	}
 
 	public void run() {
-		while(k√§ynniss√§ == true){
+		while(kaynnissa){
 			liiku();
 			render();
 			
@@ -63,12 +64,12 @@ public class Pong extends Canvas implements Runnable{
 	
 	
 	 public synchronized void start() {
-		  k√§ynniss√§ = true;
+		  kaynnissa = true;
 		  new Thread(this).start();
 		 } // End start method
 
 		 public static synchronized void stop() {
-		  k√§ynniss√§ = false;
+		  kaynnissa = false;
 		  System.exit(0);
 		 }
 		 


### PR DESCRIPTION
...assa eclipsessä (generic currency -merkkinä) ja ääkköset ei käänny kaikissa ohjelmissa. Varmaan myös opettajien päässä toivotaan vältettävän. Otin myös whilesta kaynnista == true, koska pelkka 'kaynnissa' tarkoittaa täysin samaa. Lisäsin kommentin taustakuvan yläpuolelle. Atm. polku on absoluuttinen ja toimii vain ju:n koneella, lisäksi taustakuva puuttuu tämän paketin juuresta